### PR TITLE
Make buildable on nixos

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# https://github.com/nix-community/nix-direnv
+use nix

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 # App files
 profiles/
 settings.json
+
+.direnv
+.electron

--- a/README.md
+++ b/README.md
@@ -562,3 +562,11 @@ If you have a suggestion for a new feature or a new game to support, feel free t
 To build and run the app for testing and development, ensure you have Node and NPM installed on your machine and run `npm install` and `npm run start`.
 
 To build a release, run `npm run app:build-release` for the current platform or `npm run app:build-release:all` for all supported platforms.
+
+## Setting up dev environment with nix
+
+Developing with a conventional node installation is fine. Optionally you can let nix handle the dev environment for you. nix allows to keep the environment reproducible (and makes developing on NixOS possible). See (discussion in PR #23)[https://github.com/lVlyke/stellar-mod-loader/pull/23]. This is only tested on Linux. To use nix dev shells you need to install and setup:
+- [The nix package manager](https://nixos.org/download/)
+- [direnv](https://direnv.net/), optimally with [a shell hook](https://direnv.net/docs/hook.html)
+- [nix-direnv](https://github.com/nix-community/nix-direnv)
+- run `direnv allow` to allowlist the shell.nix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.0.tgz",
       "integrity": "sha512-GJDwtZ+7XmAAbzCbPSJrR1iMs2l16VoA7myeVl6n5k/KsZywqb4KhPmjzLKpQlAFP0NRjg1LbHc2Fsus7/Ydag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -985,6 +986,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.1.tgz",
       "integrity": "sha512-j7dg18PJIbyeU4DTko3vIK3M2OuUv3H0ZViNddOaLlGN5X93cq4QCGcNhcGm3x3r5rUr/AaexYu+KHMyN8PwmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1049,6 +1051,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.0.tgz",
       "integrity": "sha512-dm8PR94QY3DucXxltdV5p2Yxyr5bfPlmjOElwLhiTvxWbwCZJTVhPc8dw0TCKzCEu+tKafT48u4BLIB34a0A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1065,6 +1068,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.0.tgz",
       "integrity": "sha512-xGBD0C9ikH4jVDuQU3XzGqbh9Wovl8UR0wNzNd9rm4fltfC9ipz9NbfetsLPKWpPbfnUqmqMe4/pYjGEgWMonw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1086,6 +1090,7 @@
       "integrity": "sha512-IFl3LNfFanspS4gHjn207TPuoJGGieuC9r+j3nDitUcFH49fbShYLGCB6xczvK+j68ZWCqv4voxAOmLyfA/Opw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1114,6 +1119,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.0.tgz",
       "integrity": "sha512-WKTRltOt3MMWWuhRX7Y9RonKxIYjZeBDE6XRwceHMgaEDS2d8I2D3AIuqizRsgHpJqDPnQnH+vxcek4FivcSGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1130,6 +1136,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.0.tgz",
       "integrity": "sha512-/GHQgiDPUr1vMXCB1O8c+O70DcoZykDBzOICCaz3kTu46rp48g6E6iaZVJoozI0iBwB8+rnuTPQnLWJ46w+wVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1148,6 +1155,7 @@
       "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.1.tgz",
       "integrity": "sha512-hA+HVIJn/y72vXv/X1JRbrL/tynW95wYMQF2fV3lIeeAmmFKkkzextBaE9rTaiW6pVN6LXoRvLJl2Vyi9jIHzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1165,6 +1173,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.0.tgz",
       "integrity": "sha512-rt3byGZWU0jF6QCLxjP+LH94uL0VM5LgtJ+tYclJqCNB1C3fZrpa86GVd9onVbZmDk0ETUOwm7dQHYdef8oiqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1249,6 +1258,7 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3865,6 +3875,7 @@
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -4264,6 +4275,7 @@
       "resolved": "https://registry.npmjs.org/@lithiumjs/angular/-/angular-8.0.1.tgz",
       "integrity": "sha512-W1bmcwvr11GGoq/tfE/OeKJHgwtb9Uk2bvJ5Hdip6730wxYruykPMzmYHYLnkTv/lhYCw995ydCSRwZ1R65KwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4822,6 +4834,7 @@
       "resolved": "https://registry.npmjs.org/@ngxs/store/-/store-19.0.0.tgz",
       "integrity": "sha512-h8xMl3OisrYabdfbUQjy98X/BSaId8t0iX3VlQgOmG0sYuC5OuZvggZywn0urLkA3H97LEI7ihvuS8spEBo6YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6131,6 +6144,7 @@
       "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -6560,6 +6574,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7062,6 +7077,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -10462,7 +10478,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
       "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -10485,6 +10502,7 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10619,6 +10637,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -10987,6 +11006,7 @@
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13419,6 +13439,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -14453,6 +14474,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14501,6 +14523,7 @@
       "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -15675,6 +15698,7 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15920,7 +15944,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.0.1",
@@ -15976,6 +16001,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16340,6 +16366,7 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -16417,6 +16444,7 @@
       "integrity": "sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16995,7 +17023,8 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
       "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/scripts/fix-7zip-bin-permissions.js
+++ b/scripts/fix-7zip-bin-permissions.js
@@ -5,13 +5,17 @@ const sevenBin = require("7zip-bin");
 // Workaround for 7zip-bin issue: https://github.com/develar/7zip-bin/issues/19
 // TODO - Remove when this issue is fixed
 if (process.platform !== "win32") {
-    execSync(
-        `chmod +x ${sevenBin.path7za}`,
-        { stdio: "inherit" }
-    );
+    try {
+        execSync(
+            `chmod +x ${sevenBin.path7za}`,
+            { stdio: "inherit" }
+        );
 
-    execSync(
-        `chmod +x ${sevenBin.path7x}`,
-        { stdio: "inherit" }
-    );
+        execSync(
+            `chmod +x ${sevenBin.path7x}`,
+            { stdio: "inherit" }
+        );
+    } catch (error) {
+        console.error("Failed to set executable permissions for 7zip binaries: ", error);
+    }
 }

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -26,7 +26,7 @@ function startApp(buildTask) {
     console.log("Starting Electron app");
 
     electronProcess = spawn("npx", [
-        "electron",
+        process.env.ELECTRON_BINARY ?? 'electron',
         BUILD_DIR,
         ...DISABLE_SANDBOX ? ["--no-sandbox"] : []
     ]);

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,79 @@
+let
+  pkgs = import <nixpkgs> { };
+
+  buildInputs = with pkgs; [
+    # Node tooling
+    nodejs_20
+
+    # Python tooling
+    # python3
+
+    # Native build tools (used by some native Node/Electron modules)
+    pkg-config
+    openssl
+    gnumake
+    cmake
+    gcc
+    binutils
+
+    # X/GL libraries required for Electron and native modules
+    libxkbcommon
+    libGL
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libXt
+    xorg.libXinerama
+    xorg.libXfixes
+    xorg.libXdamage
+    xorg.libXcomposite
+    xorg.libXScrnSaver
+    xorg.libXrender
+
+    nss
+    nspr
+    atk
+    gtk3
+    glib
+    pango
+    cairo
+    gdk-pixbuf
+    dbus
+    cups
+    alsa-lib
+
+    p7zip
+    unar # For unpacking RAR and other archive formats
+  ];
+in
+pkgs.mkShell {
+  inherit buildInputs;
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+  shellHook = ''
+    echo "Node: $(node --version)"
+    echo "npm:  $(npm --version)"
+    # echo "Python: $(python --version)"
+
+    # Ensure node-gyp and other native builds use the same Python
+    # export npm_config_python=$(which python)
+
+    # When building native Electron modules, use Electron headers matching our electron version
+    export npm_config_runtime=electron
+    export npm_config_target=35.0.0
+    export npm_config_disturl=https://electronjs.org/headers
+
+    export USE_SYSTEM_7ZA=true
+
+    export ELECTRON_BINARY="$PWD/.electron"
+    cat > "$ELECTRON_BINARY" <<'EOF'
+    #!/usr/bin/env bash
+    export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath buildInputs}
+    export USE_SYSTEM_7ZA=true
+    exec "${pkgs.electron}/bin/electron" "$@" "--enable-features=UseOzonePlatform" "--ozone-platform=x11"
+    EOF
+    chmod +x "$ELECTRON_BINARY"
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,47 +3,7 @@ let
 
   buildInputs = with pkgs; [
     # Node tooling
-    nodejs_20
-
-    # Python tooling
-    # python3
-
-    # Native build tools (used by some native Node/Electron modules)
-    pkg-config
-    openssl
-    gnumake
-    cmake
-    gcc
-    binutils
-
-    # X/GL libraries required for Electron and native modules
-    libxkbcommon
-    libGL
-    xorg.libX11
-    xorg.libxcb
-    xorg.libXcursor
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXtst
-    xorg.libXt
-    xorg.libXinerama
-    xorg.libXfixes
-    xorg.libXdamage
-    xorg.libXcomposite
-    xorg.libXScrnSaver
-    xorg.libXrender
-
-    nss
-    nspr
-    atk
-    gtk3
-    glib
-    pango
-    cairo
-    gdk-pixbuf
-    dbus
-    cups
-    alsa-lib
+    nodejs_24
 
     p7zip
     unar # For unpacking RAR and other archive formats
@@ -55,10 +15,6 @@ pkgs.mkShell {
   shellHook = ''
     echo "Node: $(node --version)"
     echo "npm:  $(npm --version)"
-    # echo "Python: $(python --version)"
-
-    # Ensure node-gyp and other native builds use the same Python
-    # export npm_config_python=$(which python)
 
     # When building native Electron modules, use Electron headers matching our electron version
     export npm_config_runtime=electron


### PR DESCRIPTION
Thanks for the awesome project! I was really struggling with setting up mo2 or vortex on linux, but this worked flawlessly. 
I made some changes to get this to build on nixos, but I think they are not interfering with other operating systems, so I wanted to contribute my work on this. 

My nixos dev flow is based on direnv and nix-direnv. When entering the projectfolder via terminal, nix-direnv is called via the .envrc and the shell.nix is evaluated, dependencies are grabbed and set up, and `npm run start` should succeed straight away.w

I'll draft a nix derivation to publish the mod loader to nixpkgs so its available to install via nix and on nixos if that's alright with you.