### PR TITLE
Improve case normalization of directories

### DIFF
--- a/src/electron/services/profile-data-manager.ts
+++ b/src/electron/services/profile-data-manager.ts
@@ -23,7 +23,7 @@ export class ProfileDataManager {
 
     constructor(
         private readonly app: ElectronApp
-    ) {}
+    ) { }
 
     private get appDataManager(): AppDataManager {
         return this.app.appDataManager;
@@ -190,8 +190,7 @@ export class ProfileDataManager {
         }
 
         // BC: <0.11.0
-        if ("gameRootDir" in profile)
-        {
+        if ("gameRootDir" in profile) {
             profile.gameInstallation = {};
 
             if ("gameRootDir" in profile) {
@@ -241,7 +240,9 @@ export class ProfileDataManager {
 
         // BC: <0.14.0
         {
-            if (this.appDataManager.loadSettings()?.normalizePathCasing) {
+            if ("gameInstallation" in profile
+                && profile.normalizePathCasing === undefined
+                && this.appDataManager.loadSettings()?.normalizePathCasing) {
                 profile.normalizePathCasing = true;
             }
         }
@@ -328,7 +329,7 @@ export class ProfileDataManager {
     ): string | undefined {
         const profileConfigDir = this.getProfileConfigDir(profile);
         let profileConfigFilePath = path.join(profileConfigDir, fileName);
-        
+
         if (!fs.existsSync(profileConfigFilePath)) {
             // Attempt to load default config values if profile file doesn't exist yet
             if (loadDefaults) {
@@ -346,7 +347,7 @@ export class ProfileDataManager {
 
     public readProfileSaveFiles(profile: AppProfile): AppProfile.Save[] {
         const profileSaveDir = this.getProfileSaveDir(profile);
-        
+
         if (!fs.existsSync(profileSaveDir)) {
             return [];
         }
@@ -362,21 +363,21 @@ export class ProfileDataManager {
                 name: path.parse(saveFileName).name,
                 date: fs.statSync(path.join(profileSaveDir, saveFileName)).mtime
             }));
-        
+
         return orderBy(saveFiles, ["date"], ["desc"]);
     }
 
     public updateProfileConfigFile(profile: AppProfile, fileName: string, data?: string): void {
         const profileConfigDir = this.getProfileConfigDir(profile);
         const profileConfigFilePath = path.join(profileConfigDir, fileName);
-        
+
         fs.mkdirpSync(profileConfigDir);
         fs.writeFileSync(profileConfigFilePath, data ?? "", "utf8");
     }
 
     public deleteProfileSaveFile(profile: AppProfile, save: AppProfile.Save): boolean {
         const profileSaveDir = this.getProfileSaveDir(profile);
-        
+
         if (!fs.existsSync(profileSaveDir)) {
             return false;
         }
@@ -501,7 +502,7 @@ export class ProfileDataManager {
         restoredPlugins.push(...profile.plugins.filter((existingPlugin) => !restoredPlugins.some((restoredPlugin) => {
             return existingPlugin.plugin === restoredPlugin.plugin && existingPlugin.modId === restoredPlugin.modId;
         })));
-        
+
         // Return the updated profile
         return Object.assign(profile, { plugins: restoredPlugins });
     }
@@ -531,7 +532,7 @@ export class ProfileDataManager {
                 );
             }
         });
-        
+
         // Return the profile
         return profile;
     }
@@ -721,7 +722,7 @@ export class ProfileDataManager {
             if (!profileModFiles) {
                 throw new Error("Unable to read deployment metadata.");
             }
-            
+
             // Filter deployed files
             modDirFiles = modDirFiles.filter(file => !profileModFiles.includes(file.toLowerCase()));
         }
@@ -829,7 +830,7 @@ export class ProfileDataManager {
         if (path.resolve(profile.gameInstallation.modDir) === gameRootDir) {
             modsToSearch.push(...profile.mods);
         }
-        
+
         // Find available game binaries and add them as actions
         return gameDetails?.gameBinary.slice().reverse().reduce((gameActions, gameBinary) => {
             gameBinary = path.normalize(gameBinary);
@@ -848,7 +849,7 @@ export class ProfileDataManager {
                     return modFile.endsWith(gameBinary);
                 })
             });
-    
+
             if (binaryExists) {
                 if (profile.gameInstallation.steamId && gameBinary === gameDetails.gameBinary[0]) {
                     // Check if we need to add environment vars for this action
@@ -968,7 +969,7 @@ export class ProfileDataManager {
             fs.writeFileSync(configFilePath, configFileData, { encoding: "utf-8" });
         }
     }
-    
+
     public findPluginFiles(profile: AppProfile): GamePluginProfileRef[] {
         const gameDb = this.appDataManager.loadGameDatabase();
         const gameDetails = gameDb[profile.gameId];
@@ -982,7 +983,7 @@ export class ProfileDataManager {
                 if (gameDetails.pluginDataRoot) {
                     pluginDirPath = path.join(pluginDirPath, gameDetails.pluginDataRoot);
                 }
-                
+
                 if (fs.existsSync(pluginDirPath)) {
                     const pluginFiles = fs.readdirSync(pluginDirPath, { encoding: "utf-8", recursive: false });
                     const modPlugins = pluginFiles
@@ -1037,7 +1038,7 @@ export class ProfileDataManager {
             } break;
             default: throw new Error("Unknown GameActionType.");
         }
-        
+
         // Apply environment variables:
         let envDict: Record<string, string | undefined> = { ...process.env };
         if (gameAction.environment) {
@@ -1050,14 +1051,14 @@ export class ProfileDataManager {
         }
 
         log.info("Running game action: ", gameActionCmd);
-        
+
         // Run the action
         try {
             exec(gameActionCmd, {
                 cwd: profile.gameInstallation.rootDir,
                 env: envDict
             });
-        } catch(error) {
+        } catch (error) {
             log.error(error);
             return false;
         }
@@ -1106,7 +1107,7 @@ export class ProfileDataManager {
         if (protonCompatDataRoot !== undefined) {
             launchOptions += PathUtils.serializeEnvironmentVariables([
                 ["STEAM_COMPAT_DATA_PATH", protonCompatDataRoot],
-            ], "linux"); 
+            ], "linux");
         }
 
         if (gameAction.environment) {
@@ -1129,7 +1130,7 @@ export class ProfileDataManager {
                 // Compute working directory:
                 const unquotedActionData = gameAction.actionData.replace(/["']+/g, "");
                 workingDir = path.dirname(unquotedActionData);
-            
+
                 if (!path.isAbsolute(workingDir)) {
                     workingDir = path.join(profile.gameInstallation.rootDir, workingDir);
                 }
@@ -1180,7 +1181,7 @@ export class ProfileDataManager {
         return SteamUtils.resolveGameId64(appId.toString());
     }
 
-    /** 
+    /**
      * @description Determines whether or not **any** profile is deployed in the `gameModDir` of `profile`.
      */
     public isSimilarProfileDeployed(profile: AppProfile): boolean {
@@ -1188,7 +1189,7 @@ export class ProfileDataManager {
         return fs.existsSync(metaFilePath);
     }
 
-    /** 
+    /**
      * @description Determines whether or the specific profile is deployed in the `gameModDir` of `profile`.
      */
     public isProfileDeployed(profile: AppProfile): boolean {

--- a/src/electron/services/profile-deployment-manager.ts
+++ b/src/electron/services/profile-deployment-manager.ts
@@ -66,13 +66,7 @@ export class ProfileDeploymentManager {
 
                     // If file path normalization is enabled, apply to all files inside Data subdirectories (i.e. textures/, meshes/)
                     if (profile.normalizePathCasing && modFile.includes(path.sep)) {
-                        // Convert file paths to lowercase
-                        // If this file is a plugin, preserve the plugin name's casing
-                        if (gamePluginFormats.some(pluginFormat => modFile.endsWith(pluginFormat))) {
-                            modFile = path.join(path.dirname(modFile).toLowerCase(), path.basename(modFile));
-                        } else {
-                            modFile = modFile.toLowerCase();
-                        }
+                        modFile = PathUtils.normalizeDeployedModFilePath(modFile, gamePluginFormats);
 
                         // Apply existing capitalization rules of mod data subdirectories to ensure only one folder is created
                         let modFileBase = path.dirname(modFile);

--- a/src/electron/services/profile-mod-manager.ts
+++ b/src/electron/services/profile-mod-manager.ts
@@ -28,7 +28,7 @@ export class ProfileModManager {
 
     constructor(
         private readonly app: ElectronApp
-    ) {}
+    ) { }
 
     private get appDataManager(): AppDataManager {
         return this.app.appDataManager;
@@ -38,11 +38,21 @@ export class ProfileModManager {
         return this.app.profileDataManager;
     }
 
+    private normalizeOverwriteFilePath(
+        filePath: string,
+        normalizePathCasing: boolean,
+        gamePluginFormats: string[]
+    ): string {
+        return normalizePathCasing
+            ? PathUtils.normalizeDeployedModFilePath(filePath, gamePluginFormats)
+            : filePath;
+    }
+
     public async beginModAdd(profile: AppProfile, root: boolean, modPath?: string): Promise<ModImportRequest | undefined> {
         if (!modPath) {
             const pickedFile = (await dialog.showOpenDialog({
                 filters: [
-                    { 
+                    {
                         name: "Mod", extensions: [
                             "zip",
                             "rar",
@@ -52,10 +62,10 @@ export class ProfileModManager {
                     }
                 ]
             }));
-            
+
             modPath = pickedFile?.filePaths[0];
         }
-        
+
         const filePath = modPath ?? "";
         if (!!filePath) {
             if (fs.lstatSync(filePath).isDirectory()) {
@@ -114,7 +124,7 @@ export class ProfileModManager {
             const pickedModFolder = await dialog.showOpenDialog({
                 properties: ["openDirectory"]
             });
-            
+
             modPath = pickedModFolder?.filePaths[0];
         }
 
@@ -145,7 +155,7 @@ export class ProfileModManager {
         const gameDetails = gameDb[profile.gameId];
         const gamePluginFormats = gameDetails?.pluginFormats ?? [];
         let foundModSubdirRoot = "";
-        
+
         if (!root && profile.gameInstallation) {
             const modDirRelName = path.relative(profile.gameInstallation.rootDir, profile.gameInstallation.modDir);
             // If mod dir is child of root dir, determine if mod is packaged relative to root dir
@@ -177,7 +187,7 @@ export class ProfileModManager {
         const fomodModuleConfigFile = modPreparedFilePaths.find(({ filePath }) => filePath.toLowerCase().endsWith(`fomod${path.sep}moduleconfig.xml`));
         if (!!fomodModuleInfoFile || !!fomodModuleConfigFile) {
             do {
-                
+
                 const xmlParser = new xml2js.Parser({
                     mergeAttrs: true,
                     trim: true,
@@ -189,7 +199,7 @@ export class ProfileModManager {
                 // Parse info.xml (optional)
                 if (fomodModuleInfoFile) {
                     try {
-                        const fullInfoFilePath =  path.join(modImportPath, fomodModuleInfoFile.filePath);
+                        const fullInfoFilePath = path.join(modImportPath, fomodModuleInfoFile.filePath);
                         const fileInfo = await detectFileEncodingAndLanguage(fullInfoFilePath);
                         const fileEncoding = (fileInfo.encoding?.toLowerCase() ?? "utf-8") as BufferEncoding;
                         const moduleInfoXml = fs.readFileSync(
@@ -205,7 +215,7 @@ export class ProfileModManager {
                 // Parse ModuleConfig.xml (optional)
                 if (fomodModuleConfigFile) {
                     try {
-                        const fullConfigFilePath =  path.join(modImportPath, fomodModuleConfigFile.filePath);
+                        const fullConfigFilePath = path.join(modImportPath, fomodModuleConfigFile.filePath);
                         const fileInfo = await detectFileEncodingAndLanguage(fullConfigFilePath);
                         const fileEncoding = (fileInfo.encoding?.toLowerCase() ?? "utf-8") as BufferEncoding;
                         const moduleConfigXml = fs.readFileSync(
@@ -251,13 +261,13 @@ export class ProfileModManager {
                             moduleImage: fomodModuleConfig.config.moduleImage?.[0]
                         };
                     }
-                    
+
                     installer = {
                         info: moduleInfo,
                         config: moduleConfig,
                         zeroConfig: !moduleConfig?.installSteps
                     };
-                }  catch (err) {
+                } catch (err) {
                     log.error(`${modName} - Failed to parse FOMOD data: `, err);
                     break;
                 }
@@ -272,7 +282,7 @@ export class ProfileModManager {
                         foundModSubdirRoot = "";
                     }
                 }
-            } while(false);
+            } while (false);
         }
 
         return {
@@ -308,7 +318,7 @@ export class ProfileModManager {
         }: ModImportRequest
     ): Promise<ModImportResult | undefined> {
         try {
-            // If the import status is anything except `PENDING`, an error occurred. 
+            // If the import status is anything except `PENDING`, an error occurred.
             if (importStatus !== "PENDING") {
                 return undefined;
             }
@@ -341,7 +351,7 @@ export class ProfileModManager {
                                 if (!pathMapSrcNorm.startsWith(modSubdirRoot.toLowerCase())) {
                                     pathMapSrcNorm = path.join(modSubdirRoot, pathMapSrcNorm).toLowerCase();
                                 }
-        
+
                                 return filEntryMatchesPath(pathMapSrcNorm);
                             });
                         } else {
@@ -414,9 +424,9 @@ export class ProfileModManager {
                                 break;
                             }
                         }
-                        
+
                         const destFilePath = path.join(modProfilePath, modFilePrefix ?? "", rootFilePath);
-                        
+
                         // Copy all enabled files to the final mod folder
                         if (externalImport) {
                             // Copy files from external imports
@@ -475,7 +485,7 @@ export class ProfileModManager {
 
         function recordResult(
             results: AppProfile.VerificationResultRecord<string>,
-            modName: string, 
+            modName: string,
             result: AppProfile.VerificationResult
         ) {
             const existingResult = (results[modName] ?? {
@@ -484,11 +494,11 @@ export class ProfileModManager {
             }) as AppProfile.VerificationResult;
             existingResult.error ||= result.error;
             existingResult.found &&= result.found;
-            
+
             if (result.error && result.reason) {
                 existingResult.reason = existingResult.reason ? `${existingResult.reason}; ${result.reason}` : result.reason;
             }
-            
+
             results[modName] = existingResult;
         }
 
@@ -497,7 +507,7 @@ export class ProfileModManager {
             const modExists = fs.existsSync(path.join(mod.baseProfile
                 ? this.profileDataManager.getProfileModsDir(profile.baseProfile!)
                 : modsDir,
-            modName));
+                modName));
 
             recordResult(result, modName, {
                 error: !modExists,
@@ -506,7 +516,7 @@ export class ProfileModManager {
             });
 
             // Check if profile has any mods that conflict with the base profile
-            const modConflictsWithBase = !mod.baseProfile && !!baseProfileModList.find(([baseModName]) => baseModName === modName); 
+            const modConflictsWithBase = !mod.baseProfile && !!baseProfileModList.find(([baseModName]) => baseModName === modName);
 
             recordResult(result, modName, {
                 error: modConflictsWithBase,
@@ -542,8 +552,10 @@ export class ProfileModManager {
         root: boolean,
         task: (modOverwriteFiles: ModOverwriteFilesEntry[], modName: string, modRef: ModProfileRef, completed: boolean) => Promise<unknown>
     ): Promise<void> {
-        const fileCache: ModOverwriteFilesEntry[] = [];
+        const fileCache: Array<ModOverwriteFilesEntry & { normalizedFiles: string[] }> = [];
         const modsList = root ? profile.rootMods : profile.mods;
+        const gamePluginFormats = this.appDataManager.getGameDetails(profile.gameId)?.pluginFormats ?? [];
+        const normalizePathCasing = "normalizePathCasing" in profile && !!profile.normalizePathCasing;
 
         // Add external files to cache
         if ("externalFilesCache" in profile) {
@@ -562,7 +574,12 @@ export class ProfileModManager {
                 }
             }
 
-            fileCache.push({ files: externalFiles });
+            fileCache.push({
+                files: externalFiles,
+                normalizedFiles: externalFiles.map((filePath) => {
+                    return this.normalizeOverwriteFilePath(filePath, normalizePathCasing, gamePluginFormats);
+                })
+            });
         }
 
         for (let modIndex = 0; modIndex < modsList.length; ++modIndex) {
@@ -582,16 +599,16 @@ export class ProfileModManager {
 
                 const modOverwriteFiles: ModOverwriteFilesEntry[] = [];
                 await AsyncUtils.batchTaskAsync(modDirFiles, 100, async (modFile) => {
-                    // TODO - Normalize path case if enabled
-                    const overwrittenFiles = fileCache.filter(fileEntry => fileEntry.files.includes(modFile));
-                    
+                    const normalizedModFile = this.normalizeOverwriteFilePath(modFile, normalizePathCasing, gamePluginFormats);
+                    const overwrittenFiles = fileCache.filter((fileEntry) => fileEntry.normalizedFiles.includes(normalizedModFile));
+
                     // Record any overwritten files
                     if (overwrittenFiles.length > 0) {
                         for (const overwrittenFile of overwrittenFiles) {
                             const overwriteEntry = modOverwriteFiles.find((fileEntry) => {
                                 return fileEntry.modName === overwrittenFile.modName;
                             });
-                            
+
                             if (!!overwriteEntry) {
                                 overwriteEntry.files.push(modFile);
                             } else {
@@ -602,7 +619,13 @@ export class ProfileModManager {
                 });
 
                 // Add files to cache
-                fileCache.push({ modName, files: modDirFiles });
+                fileCache.push({
+                    modName,
+                    files: modDirFiles,
+                    normalizedFiles: modDirFiles.map((filePath) => {
+                        return this.normalizeOverwriteFilePath(filePath, normalizePathCasing, gamePluginFormats);
+                    })
+                });
 
                 // Notify of new overwrite files
                 await task(modOverwriteFiles, modName, modRef, modIndex === modsList.length - 1);

--- a/src/electron/util/path-utils.ts
+++ b/src/electron/util/path-utils.ts
@@ -222,4 +222,30 @@ export namespace PathUtils {
 
         return existingFile ? path.join(dirName, existingFile) : undefined;
     }
+
+    export function normalizeModDirPath(dirPath: string): string {
+        return dirPath
+            .split(path.sep)
+            .map((pathPart) => {
+                const normalizedPart = pathPart.toLowerCase();
+                return normalizedPart.length > 0
+                    ? normalizedPart.charAt(0).toUpperCase() + normalizedPart.slice(1)
+                    : normalizedPart;
+            })
+            .join(path.sep);
+    }
+
+    export function normalizeDeployedModFilePath(filePath: string, gamePluginFormats: string[]): string {
+        if (!filePath.includes(path.sep)) {
+            return filePath;
+        }
+
+        const normalizedDirPath = normalizeModDirPath(path.dirname(filePath));
+
+        if (gamePluginFormats.some((pluginFormat) => filePath.endsWith(pluginFormat))) {
+            return path.join(normalizedDirPath, path.basename(filePath));
+        }
+
+        return path.join(normalizedDirPath, path.basename(filePath).toLowerCase());
+    }
 }


### PR DESCRIPTION
I went absolutely mad trying to figure out why my mods weren't loading on linux, turns out the normalization changed the directory names to lowercase (interface), but the game expects them to be uppercase (Interface)...

This should fix normalization falling back to a mostly wrong lowercase, improves the overwrite-calculation, and fixes an issue where the normalization setting wasn't loaded correctly after restarting the app. 

Maybe it would be useful to have some kind of 'expected directory structure' with the correctly capitalized directory names as part of the game definitions. 